### PR TITLE
Add background tasks with Celery and include tasks router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 
 ## [Unreleased]
-- Background updates with Celery
 - Docker setup
 - Telegram notifications
+
+---
+
+## [0.4.0] - 2025-09-15
+### Added
+- **Celery + Redis** integration for background tasks:
+  - `sync_bond_task` — update a single bond by ISIN
+  - `sync_all_bonds_task` — update all bonds in DB
+  - test task `test_task_sleep` for simulating long-running jobs
+- New router `/tasks` to trigger background jobs via API
+- Celery worker & Flower launch instructions in README
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@
 
 ---
 
+## Stage 4 — Фоновые задачи (Celery + Redis)
+
+На этом этапе добавлена интеграция с **Celery** для фонового обновления облигаций:
+
+- `sync_bond_task` — синхронизация конкретного бонда по ISIN.
+- `sync_all_bonds_task` — синхронизация всех бондов в базе.
+- Тестовая задача `test_task_sleep` — имитация долгой работы.
+
+---
+
 ## Запуск проекта
 
 ### Локально (dev)
@@ -69,3 +79,17 @@
 4. Документация доступна по адресу:
    ```bash
    http://127.0.0.1:8000/docs
+
+### Запуск Celery
+
+1. Запустить Redis (локально или в Docker):
+   ```bash
+   docker run -p 6379:6379 redis
+
+2. Запустить Celery worker:
+   ```bash
+   celery -A app.celery_tasks.celery_app.celery worker --loglevel=info
+
+3. (Опционально) Запустить Flower для мониторинга задач:
+   ```bash
+   celery -A app.celery_tasks.celery_app.celery flower --port=5555

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -1,11 +1,35 @@
+import time
+
 from fastapi import APIRouter
-from app.celery_tasks.tasks import sync_all_bonds_task
+from celery.result import AsyncResult
+
+from app.celery_tasks.tasks import sync_bond_task, sync_all_bonds_task
+from app.celery_tasks.celery_app import celery
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 
-router = APIRouter(prefix="/tasks", tags=["Tasks"])
+@router.post("/sync/{isin}")
+def sync_bond(isin: str):
+    """Запустить синхронизацию конкретного бонда в фоне."""
+    task = sync_bond_task.delay(isin)
+    return {"task_id": task.id, "status": "PENDING"}
+
 
 @router.post("/sync_all")
-def run_sync_all():
-    """Запустить фоновое обновление всех бондов."""
-    sync_all_bonds_task.delay()
-    return {"status": "sync_all_bonds_task started"}
+def sync_all_bonds():
+    """Запустить обновление всех бондов в фоне."""
+    task = sync_all_bonds_task.delay()
+    # time.sleep(30)
+    return {"task_id": task.id, "status": "PENDING"}
+
+
+@router.get("/{task_id}")
+def get_task_status(task_id: str):
+    """Проверить статус фоновой задачи."""
+    result = AsyncResult(task_id, app=celery)
+    return {
+        "task_id": task_id,
+        "status": result.status,
+        "result": result.result if result.ready() else None
+    }

--- a/app/services/moex_client.py
+++ b/app/services/moex_client.py
@@ -28,13 +28,7 @@ async def get_bond_info(isin: str) -> Optional[dict]:
     if not rows:
         return None
     bond_data = {row[0]: row[2] for row in rows}
-
-    # Добавляем поле оферты
-    # buyback_raw = bond_data.get("BUYBACKDATE")
-    # print(buyback_raw)
-    # bond_data["has_offer"] = bool(buyback_raw)
-    # bond_data["offer_date"] = datetime.strptime(buyback_raw, "%Y-%m-%d").date() if buyback_raw else None
-    print(bond_data)
+    # print(bond_data)
     return bond_data
 
 

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 # from app.database import engine, Base
 from app.routers import bonds, moex, tasks
 
-app = FastAPI(title="BondWatch API", version="0.3")
+app = FastAPI(title="BondWatch API", version="0.4")
 
 app.include_router(bonds.router)
 app.include_router(moex.router)

--- a/main.py
+++ b/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
 # from app.database import engine, Base
-from app.routers import bonds, moex
+from app.routers import bonds, moex, tasks
 
-app = FastAPI(title="BondWatch API", version="0.2")
+app = FastAPI(title="BondWatch API", version="0.3")
 
 app.include_router(bonds.router)
 app.include_router(moex.router)
+app.include_router(tasks.router)
+
 
 # Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
This MR implements Stage 4 of the project: background updates using Celery.

Changes included:

- Added background tasks:

    sync_bond_task — sync a single bond by ISIN.

    sync_all_bonds_task — sync all bonds in the database.

    test_task_sleep — dummy task simulating long-running operations.

- Added app/routers/tasks.py and included it in main.py.

- Updated README and CHANGELOG with Stage 4 information.

No breaking changes; the existing MOEX integration and bond endpoints remain fully functional.